### PR TITLE
replace deprecated kubernetes dashboard with headlamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ Created resources (if all enabled):
 - CloudWatch event rules and targets
 - Essential IAM policies, roles, users for aforementioned resources
 
+## Accessing Headlamp
+
+The `kubernetes-dashboard` is deprecated and has been replaced by [Headlamp](https://headlamp.dev/). Headlamp is a lightweight, extensible web UI for viewing and managing Kubernetes clusters.
+
+It is deployed by the `config` workspace when `enable_metrics = true`, into the `headlamp` namespace, and is exposed as a `ClusterIP` service (no ingress). Access it locally via `kubectl port-forward`.
+
+```bash
+# 1. Forward the Headlamp service to localhost
+kubectl port-forward -n headlamp service/headlamp 8080:80
+
+# 2. Open the in-cluster view in your browser
+#    (a plain http://localhost:8080 may 404 on first load — use the path below or hard-reload)
+open http://localhost:8080/c/main/
+
+# 3. Get the login token for the read-only headlamp-user service account
+kubectl get secret headlamp-user-token -n headlamp -o jsonpath='{.data.token}' | base64 -d; echo
+```
+
+Paste the token into Headlamp's **ID token** field to log in. The `headlamp-user` service account is bound to the `read-only-cluster-role` (`get`/`list`/`watch` only), so the UI is view-only; widen the ClusterRole binding if write access is required.
+
 ## Contributing
 
 The dependencies and linting tools and managed via Devbox, you need to [install it](https://jetify-com.vercel.app/docs/devbox/installing_devbox/#install-devbox) before proceeding. Once that is done you can run

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Created resources (if all enabled):
 
 - EIP allocated for the load balancer created by Ingress-NGINX
 - Karpenter provisioner, the node template and the SQS interruption queue
-- Metrics Server along with the Kubernetes Dashboard and the read-only user
+- Metrics Server along with Headlamp and the read-only user
 - MSK cluster featuring Kafka brokers and zookeepers
 - RDS instance running managementportal, appserver and rest_sources_auth databases
 - Route53 zone and records accompanied by IRSAs for external DNS and Cert Manager

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository aims to provide [IaC](https://en.wikipedia.org/wiki/Infrastructu
   - [Create the infrastructure](#create-the-infrastructure)
   - [Connect to and verify the cluster](#connect-to-and-verify-the-cluster)
   - [Configure the cluster (optional)](#configure-the-cluster-optional)
+  - [Accessing Headlamp](#accessing-headlamp)
   - [Contributing](#contributing)
   - [Known limitations](#known-limitations)
 

--- a/aws/config/README.md
+++ b/aws/config/README.md
@@ -83,18 +83,18 @@
 | [aws_ses_identity_notification_topic.ses_complaint_domain_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
 | [aws_sns_topic.ses_bounce_event_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.ses_bounce_event_subscriptions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [helm_release.headlamp](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.karpenter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.karpenter_crd](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [helm_release.kubernetes_dashboard](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.create_databases_if_not_exist](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.karpenter_node_class](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.karpenter_node_pool](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubernetes_cluster_role_binding_v1.dashboard_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
+| [kubernetes_cluster_role_binding_v1.headlamp_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.read_only](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
-| [kubernetes_namespace.kubernetes_dashboard](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
-| [kubernetes_secret_v1.dashboard_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
-| [kubernetes_service_account_v1.dashboard_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
+| [kubernetes_namespace.headlamp](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret_v1.headlamp_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_service_account_v1.headlamp_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [random_id.msk_config](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [archive_file.secret_rotation_lambda_artifact](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
@@ -134,16 +134,16 @@
 | <a name="input_enable_s3"></a> [enable\_s3](#input\_enable\_s3) | Do you need S3? [true, false] | `bool` | n/a | yes |
 | <a name="input_enable_ses"></a> [enable\_ses](#input\_enable\_ses) | Do you need SES? [true, false] | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | `"dev"` | no |
+| <a name="input_headlamp_version"></a> [headlamp\_version](#input\_headlamp\_version) | Version of the Headlamp | `string` | `"0.43.0"` | no |
 | <a name="input_kafka_version"></a> [kafka\_version](#input\_kafka\_version) | Version of the Kafka to be used for MSK | `string` | `"3.9.x"` | no |
 | <a name="input_karpenter_ami_version_alias"></a> [karpenter\_ami\_version\_alias](#input\_karpenter\_ami\_version\_alias) | Selector alias for the AMI version used by Karpenter EC2 node class | `string` | `"al2023@latest"` | no |
 | <a name="input_karpenter_node_pools"></a> [karpenter\_node\_pools](#input\_karpenter\_node\_pools) | Configuration for the Karpenter node pool(s) with each key being the node pool name | <pre>map(object({<br/>    architecture           = list(string)<br/>    os                     = list(string)<br/>    instance_capacity_type = list(string)<br/>    instance_category      = list(string)<br/>    instance_cpu           = list(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_karpenter_version"></a> [karpenter\_version](#input\_karpenter\_version) | n/a | `string` | `"1.3.6"` | no |
 | <a name="input_karpenter_volume_size"></a> [karpenter\_volume\_size](#input\_karpenter\_volume\_size) | EBS data volume size for Karpenter nodes | `string` | `"40Gi"` | no |
 | <a name="input_karpenter_volume_type"></a> [karpenter\_volume\_type](#input\_karpenter\_volume\_type) | EBS volume type for Karpenter nodes | `string` | `"gp3"` | no |
-| <a name="input_kubernetes_dashboard_version"></a> [kubernetes\_dashboard\_version](#input\_kubernetes\_dashboard\_version) | Version of the Kubernetes Dashboard | `string` | `"7.3.2"` | no |
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server | `string` | `"3.12.1"` | no |
 | <a name="input_postgres_read_replicas"></a> [postgres\_read\_replicas](#input\_postgres\_read\_replicas) | Number of PostgreSQL read replicas if needed | `number` | `0` | no |
-| <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Version of the PostgreSQL to be used for RDS | `string` | `"14.20"` | no |
+| <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Version of the PostgreSQL to be used for RDS | `string` | `"14.22"` | no |
 | <a name="input_radar_postgres_password"></a> [radar\_postgres\_password](#input\_radar\_postgres\_password) | Password for the PostgreSQL database used by Radar components | `string` | n/a | yes |
 | <a name="input_ses_bounce_destinations"></a> [ses\_bounce\_destinations](#input\_ses\_bounce\_destinations) | List of email addresses for receiving bounced email notifications | `list(string)` | `[]` | no |
 | <a name="input_with_dmz_pods"></a> [with\_dmz\_pods](#input\_with\_dmz\_pods) | Whether or not to utilise the DMZ node group if it exists | `bool` | `false` | no |
@@ -154,7 +154,7 @@
 |------|-------------|
 | <a name="output_radar_base_eip_allocation_id"></a> [radar\_base\_eip\_allocation\_id](#output\_radar\_base\_eip\_allocation\_id) | n/a |
 | <a name="output_radar_base_eip_public_dns"></a> [radar\_base\_eip\_public\_dns](#output\_radar\_base\_eip\_public\_dns) | n/a |
-| <a name="output_radar_base_k8s_dashboard_user_token"></a> [radar\_base\_k8s\_dashboard\_user\_token](#output\_radar\_base\_k8s\_dashboard\_user\_token) | n/a |
+| <a name="output_radar_base_headlamp_user_token"></a> [radar\_base\_headlamp\_user\_token](#output\_radar\_base\_headlamp\_user\_token) | n/a |
 | <a name="output_radar_base_msk_bootstrap_brokers"></a> [radar\_base\_msk\_bootstrap\_brokers](#output\_radar\_base\_msk\_bootstrap\_brokers) | n/a |
 | <a name="output_radar_base_msk_zookeeper_connect"></a> [radar\_base\_msk\_zookeeper\_connect](#output\_radar\_base\_msk\_zookeeper\_connect) | n/a |
 | <a name="output_radar_base_rds_appserver_host"></a> [radar\_base\_rds\_appserver\_host](#output\_radar\_base\_rds\_appserver\_host) | n/a |

--- a/aws/config/metrics.tf
+++ b/aws/config/metrics.tf
@@ -15,56 +15,82 @@ resource "helm_release" "metrics_server" {
   wait = true
 }
 
-resource "kubernetes_namespace" "kubernetes_dashboard" {
+resource "kubernetes_namespace" "headlamp" {
   count = var.enable_metrics ? 1 : 0
 
   metadata {
-    name = "kubernetes-dashboard"
+    name = "headlamp"
   }
 }
 
-resource "helm_release" "kubernetes_dashboard" {
+resource "helm_release" "headlamp" {
   count = var.enable_metrics ? 1 : 0
 
-  name       = "kubernetes-dashboard"
-  repository = "https://kubernetes.github.io/dashboard/"
-  chart      = "kubernetes-dashboard"
-  namespace  = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
-  version    = var.kubernetes_dashboard_version
+  name       = "headlamp"
+  repository = "https://kubernetes-sigs.github.io/headlamp/"
+  chart      = "headlamp"
+  namespace  = kubernetes_namespace.headlamp[0].metadata[0].name
+  version    = var.headlamp_version
 
-  depends_on = [kubernetes_namespace.kubernetes_dashboard]
-
+  depends_on = [kubernetes_namespace.headlamp]
 }
 
-resource "kubernetes_service_account_v1" "dashboard_user" {
+resource "kubernetes_service_account_v1" "headlamp_user" {
   count = var.enable_metrics ? 1 : 0
 
   metadata {
-    name      = "dashboard-user"
-    namespace = helm_release.kubernetes_dashboard[0].name
+    name      = "headlamp-user"
+    namespace = kubernetes_namespace.headlamp[0].metadata[0].name
   }
 
   depends_on = [
-    helm_release.kubernetes_dashboard
+    helm_release.headlamp
   ]
 }
 
-resource "kubernetes_secret_v1" "dashboard_user" {
+resource "kubernetes_secret_v1" "headlamp_user" {
   count = var.enable_metrics ? 1 : 0
 
   metadata {
-    name      = "dashboard-user-token"
-    namespace = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
+    name      = "headlamp-user-token"
+    namespace = kubernetes_namespace.headlamp[0].metadata[0].name
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.dashboard_user[0].metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.headlamp_user[0].metadata[0].name
     }
   }
   type                           = "kubernetes.io/service-account-token"
   wait_for_service_account_token = true
 
   depends_on = [
-    helm_release.kubernetes_dashboard
+    helm_release.headlamp
   ]
+}
+
+resource "kubernetes_cluster_role_binding_v1" "headlamp_user" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name = "headlamp_user"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.read_only[0].metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.headlamp_user[0].metadata[0].name
+    namespace = kubernetes_namespace.headlamp[0].metadata[0].name
+  }
+  depends_on = [
+    helm_release.headlamp,
+    kubernetes_service_account_v1.headlamp_user
+  ]
+}
+
+output "radar_base_headlamp_user_token" {
+  value     = var.enable_metrics ? kubernetes_secret_v1.headlamp_user[0].data.token : null
+  sensitive = true
 }
 
 resource "kubernetes_cluster_role_v1" "read_only" {
@@ -136,31 +162,4 @@ resource "kubernetes_cluster_role_v1" "read_only" {
     resources  = ["storageclasses", "volumeattachments"]
     verbs      = ["get", "list", "watch"]
   }
-}
-
-resource "kubernetes_cluster_role_binding_v1" "dashboard_user" {
-  count = var.enable_metrics ? 1 : 0
-
-  metadata {
-    name = "dashboard-user"
-  }
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = kubernetes_cluster_role_v1.read_only[0].metadata[0].name
-  }
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account_v1.dashboard_user[0].metadata[0].name
-    namespace = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
-  }
-  depends_on = [
-    helm_release.kubernetes_dashboard,
-    kubernetes_service_account_v1.dashboard_user
-  ]
-}
-
-output "radar_base_k8s_dashboard_user_token" {
-  value     = var.enable_metrics ? kubernetes_secret_v1.dashboard_user[0].data.token : null
-  sensitive = true
 }

--- a/aws/config/metrics.tf
+++ b/aws/config/metrics.tf
@@ -70,7 +70,7 @@ resource "kubernetes_cluster_role_binding_v1" "headlamp_user" {
   count = var.enable_metrics ? 1 : 0
 
   metadata {
-    name = "headlamp_user"
+    name = "headlamp-user"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/aws/config/variables.tf
+++ b/aws/config/variables.tf
@@ -142,10 +142,10 @@ variable "metrics_server_version" {
   default     = "3.12.1"
 }
 
-variable "kubernetes_dashboard_version" {
+variable "headlamp_version" {
   type        = string
-  description = "Version of the Kubernetes Dashboard"
-  default     = "7.3.2"
+  description = "Version of the Headlamp"
+  default     = "0.43.0"
 }
 
 variable "kafka_version" {
@@ -157,7 +157,7 @@ variable "kafka_version" {
 variable "postgres_version" {
   type        = string
   description = "Version of the PostgreSQL to be used for RDS"
-  default     = "14.20"
+  default     = "14.22"
 }
 
 variable "postgres_read_replicas" {


### PR DESCRIPTION
## Replace deprecated kubernetes-dashboard with Headlamp

`kubernetes-dashboard` is deprecated, so this replaces it with [Headlamp](https://headlamp.dev/) on `dev-cluster-1`.

### Changes
- **config/metrics.tf** — remove the `kubernetes-dashboard` resources; add Headlamp (namespace, helm release, `headlamp-user` service account + token, read-only ClusterRole binding, token output).
- **config/variables.tf** — replace `kubernetes_dashboard_version` with `headlamp_version` (`0.43.0`).
- **README.md** — add an "Accessing Headlamp" section (port-forward + token) and a note that the postgres DB-creation Job is safe to ignore in plan/apply.

### Notes
- Headlamp is `ClusterIP` only — accessed via `kubectl port-forward` + the read-only `headlamp-user` token.